### PR TITLE
fix: Peg FROM image to ubuntu:14.04, as was originally intended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 
 COPY qcad-3.12.8-linux-x86_64.tar.gz /root/
 RUN cd /root && tar zxvf qcad-3.12.8-linux-x86_64.tar.gz


### PR DESCRIPTION
This works and is the ubuntu release date corresponding to what the
author had accessible at the time of the original commit.